### PR TITLE
Add Keras U-Net model for 256x256 segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # test2
 This is test 2
+
+## Semantic Segmentation Model
+
+The `segmentation_model.py` script defines a simple U-Net built with `tf.keras` for performing semantic segmentation on 256x256 RGB images.
+
+### Training
+
+The `train_unet` function in `segmentation_model.py` compiles and fits the model. Provide `tf.data.Dataset` objects that yield `(image, mask)` pairs:
+
+```python
+from segmentation_model import train_unet
+
+train_unet(train_ds, val_ds, epochs=10)
+```

--- a/segmentation_model.py
+++ b/segmentation_model.py
@@ -1,0 +1,78 @@
+import tensorflow as tf
+from tensorflow.keras import layers, models
+
+def conv_block(inputs, num_filters):
+    x = layers.Conv2D(num_filters, 3, padding='same', activation='relu')(inputs)
+    x = layers.Conv2D(num_filters, 3, padding='same', activation='relu')(x)
+    return x
+
+def encoder_block(inputs, num_filters):
+    x = conv_block(inputs, num_filters)
+    p = layers.MaxPooling2D((2, 2))(x)
+    return x, p
+
+def decoder_block(inputs, skip_features, num_filters):
+    x = layers.Conv2DTranspose(num_filters, (2, 2), strides=2, padding='same')(inputs)
+    x = layers.Concatenate()([x, skip_features])
+    x = conv_block(x, num_filters)
+    return x
+
+def build_unet(input_shape=(256, 256, 3), num_classes=1):
+    """Builds a simple U-Net model for semantic segmentation.
+
+    Args:
+        input_shape: Input image shape. Defaults to (256, 256, 3).
+        num_classes: Number of output classes. Defaults to 1.
+
+    Returns:
+        A tf.keras Model instance representing the U-Net.
+    """
+    inputs = layers.Input(shape=input_shape)
+
+    s1, p1 = encoder_block(inputs, 64)
+    s2, p2 = encoder_block(p1, 128)
+    s3, p3 = encoder_block(p2, 256)
+    s4, p4 = encoder_block(p3, 512)
+
+    b1 = conv_block(p4, 1024)
+
+    d1 = decoder_block(b1, s4, 512)
+    d2 = decoder_block(d1, s3, 256)
+    d3 = decoder_block(d2, s2, 128)
+    d4 = decoder_block(d3, s1, 64)
+
+    activation = 'softmax' if num_classes > 1 else 'sigmoid'
+    outputs = layers.Conv2D(num_classes, 1, padding='same', activation=activation)(d4)
+
+    model = models.Model(inputs, outputs, name="unet")
+    return model
+
+
+def train_unet(train_dataset,
+              val_dataset=None,
+              epochs=10,
+              num_classes=1,
+              model_path=None):
+    """Compiles and trains a U-Net model.
+
+    Args:
+        train_dataset: `tf.data.Dataset` yielding `(image, mask)` pairs for training.
+        val_dataset: Optional dataset for validation.
+        epochs: Number of training epochs. Defaults to 10.
+        num_classes: Number of output classes. Defaults to 1.
+        model_path: Optional path to save the trained model.
+
+    Returns:
+        The trained `tf.keras` model.
+    """
+    model = build_unet(num_classes=num_classes)
+    loss = "binary_crossentropy" if num_classes == 1 else "sparse_categorical_crossentropy"
+    model.compile(optimizer="adam", loss=loss, metrics=["accuracy"])
+    model.fit(train_dataset, validation_data=val_dataset, epochs=epochs)
+    if model_path:
+        model.save(model_path)
+    return model
+
+if __name__ == "__main__":
+    model = build_unet()
+    model.summary()


### PR DESCRIPTION
## Summary
- Add `train_unet` helper to compile and train the 256×256 U-Net model
- Document training usage in the README

## Testing
- `python -m py_compile segmentation_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68973dfd172c8325b90664db3300d15b